### PR TITLE
Allow level to be set for each event

### DIFF
--- a/lib/logstash/outputs/rollbar.rb
+++ b/lib/logstash/outputs/rollbar.rb
@@ -76,6 +76,7 @@ class LogStash::Outputs::Rollbar < LogStash::Outputs::Base
 
     rb_item['data']['notifier']['name'] = 'logstash'
     rb_item['data']['notifier']['version'] = '0.1.0'
+    rb_item['data']['notifier']['version'] = Gem.loaded_specs["logstash-output-rollbar"].version
 
     @logger.debug("Rollbar Item", :rb_item => rb_item)
 

--- a/lib/logstash/outputs/rollbar.rb
+++ b/lib/logstash/outputs/rollbar.rb
@@ -16,8 +16,8 @@ class LogStash::Outputs::Rollbar < LogStash::Outputs::Base
   # The Rollbar environment
   config :environment, :validate => :string, :default => 'production'
 
-  # The Rollbar event level (info, warning, error)
-  config :level, :validate => ['debug', 'info', 'warning', 'error', 'critical'] , :default => 'info'
+  # The default level for Rollbar events (info, warning, error)
+  config :default_level, :validate => ['debug', 'info', 'warning', 'error', 'critical'] , :default => 'info'
 
   # Format for the Rollbar "message" or item title. In most cases you'll want to override this
   # and build up a message with specific fields from the event.
@@ -58,7 +58,7 @@ class LogStash::Outputs::Rollbar < LogStash::Outputs::Base
     # If logstash has created 'rollbar' fields, we'll use those to populate the item...
     #
     if data['rollbar']
-      merge_keys = %w{platform language framework context request person server client fingerprint title uuid}
+      merge_keys = %w{platform language framework context request person server client fingerprint title uuid level}
       merge_keys.each do |key|
         data['rollbar'][key] && rb_item['data'][key] = data['rollbar'][key]
       end
@@ -70,7 +70,7 @@ class LogStash::Outputs::Rollbar < LogStash::Outputs::Base
 
     # ...and finally override the top level fields that have a specific meaning
     rb_item['data']['timestamp'] = event.timestamp.to_i
-    rb_item['data']['level'] = @level
+    rb_item['data']['level'] ||= @default_level
     rb_item['data']['environment'] = @environment
     rb_item['data']['body']['message']['body'] = event.sprintf(@format)
 

--- a/lib/logstash/outputs/rollbar.rb
+++ b/lib/logstash/outputs/rollbar.rb
@@ -10,17 +10,24 @@ require "json"
 class LogStash::Outputs::Rollbar < LogStash::Outputs::Base
   config_name "rollbar"
 
-  # Your Rollbar access token
+  # Each of these config values can be specified in the plugin configuration section, in which
+  # case they'll apply to all events, or you can override them on an event by event basis.
+  #
+  # Your default Rollbar access token. You can override this for a specific event by adding
+  # a "[rollbar][access_token]" field to that event
   config :access_token, :validate => :password, :required => true
 
-  # The Rollbar environment
+  # The default Rollbar environment. You can override this for a specific event by adding
+  # a "[rollbar][environment]" field to that event
   config :environment, :validate => :string, :default => 'production'
 
-  # The default level for Rollbar events (info, warning, error)
-  config :default_level, :validate => ['debug', 'info', 'warning', 'error', 'critical'] , :default => 'info'
+  # The default level for Rollbar events (info, warning, error) You can override this for a specific
+  # event by adding a "[rollbar][level]" field to that event
+  config :level, :validate => ['debug', 'info', 'warning', 'error', 'critical'] , :default => 'info'
 
-  # Format for the Rollbar "message" or item title. In most cases you'll want to override this
-  # and build up a message with specific fields from the event.
+  # The default format for the Rollbar "message" or item title. In most cases you'll want to override
+  # this and build up a message with specific fields from the event. You can override this for a specific
+  # event by adding a "[rollbar][format]" field to that event.
   config :format, :validate => :string, :default => "%{message}"
 
   # Rollbar API URL endpoint. You shouldn't need to change this.
@@ -49,7 +56,6 @@ class LogStash::Outputs::Rollbar < LogStash::Outputs::Base
     return unless output?(event)
 
     rb_item = hash_recursive
-    rb_item['access_token'] = @access_token.value
 
     # We'll want to remove fields from data without removing them from the original event
     data = JSON.parse(event.to_json)
@@ -58,7 +64,9 @@ class LogStash::Outputs::Rollbar < LogStash::Outputs::Base
     # If logstash has created 'rollbar' fields, we'll use those to populate the item...
     #
     if data['rollbar']
-      merge_keys = %w{platform language framework context request person server client fingerprint title uuid level}
+
+      merge_keys = %w{access_token client context environment fingerprint format framework
+                      language level person platform request server title uuid }
       merge_keys.each do |key|
         data['rollbar'][key] && rb_item['data'][key] = data['rollbar'][key]
       end
@@ -68,15 +76,33 @@ class LogStash::Outputs::Rollbar < LogStash::Outputs::Base
     # ...then put whatever's left in 'custom'...
     rb_item['data']['custom'] = data
 
-    # ...and finally override the top level fields that have a specific meaning
+    # ...and finally override the fields that have a specific meaning
     rb_item['data']['timestamp'] = event.timestamp.to_i
-    rb_item['data']['level'] ||= @default_level
-    rb_item['data']['environment'] = @environment
-    rb_item['data']['body']['message']['body'] = event.sprintf(@format)
+    rb_item['data']['level'] = @level unless rb_item['data'].has_key?('level')
+    rb_item['data']['environment'] = @environment unless rb_item['data'].has_key?('environment')
 
     rb_item['data']['notifier']['name'] = 'logstash'
-    rb_item['data']['notifier']['version'] = '0.1.0'
     rb_item['data']['notifier']['version'] = Gem.loaded_specs["logstash-output-rollbar"].version
+
+    # Construct the message body using either:
+    #
+    # - The default format string defined above "%{message}"
+    # - The format string specified in the rollbar plugin config section
+    # - The format string specified in the [rollbar][format] event field
+    #
+    format = rb_item['data'].has_key?('format') ? rb_item['data']['format'] : @format
+    rb_item['data']['body']['message']['body'] = event.sprintf(format)
+
+    # Treat the [rollbar][access_token] field as a special case, since we don't need to
+    # include it more than once in the Rollbar item
+    #
+    if rb_item['data'].has_key?('access_token')
+      rb_item['access_token'] = rb_item['data']['access_token']
+      rb_item['data'].delete('access_token')
+    else
+      rb_item['access_token'] = @access_token.value
+    end
+
 
     @logger.debug("Rollbar Item", :rb_item => rb_item)
 

--- a/lib/logstash/outputs/rollbar.rb
+++ b/lib/logstash/outputs/rollbar.rb
@@ -9,7 +9,6 @@ require "json"
 # applications, you can use the same token.
 class LogStash::Outputs::Rollbar < LogStash::Outputs::Base
   config_name "rollbar"
-  milestone 1
 
   # Your Rollbar access token
   config :access_token, :validate => :password, :required => true

--- a/logstash-output-rollbar.gemspec
+++ b/logstash-output-rollbar.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-rollbar'
-  s.version         = '0.1.3'
+  s.version         = '0.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The Rollbar Logstash output sends events to the Rollbar error monitoring service."
   s.description     = "This gem is a logstash plugin. Install using: $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-rollbar.gemspec
+++ b/logstash-output-rollbar.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-rollbar'
-  s.version         = '0.1.2'
+  s.version         = '0.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The Rollbar Logstash output sends events to the Rollbar error monitoring service."
   s.description     = "This gem is a logstash plugin. Install using: $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Instead of specifying a `level` to be used for all events sent to Rollbar, you now specify a `default_level`.

```
  rollbar {
    access_token => "TOKEN"
    endpoint => "https://api-alt.rollbar.com/api/1/item/"
    default_level => "info"
  }
```

You can override this level by adding a field to the event like:

```
filter {
  mutate {
    add_field => { "[rollbar][platform]" => "linux" }
    add_field => { "[rollbar][server][host]" => "%{host}" }
    add_field => { "[rollbar][level]" => "%{level}" }
  }
}
```

Note that if the value passed to Rollbar for level isn't recognized (i.e. isn't one of `debug`, `info`, `warning`, `error`, or `critical`) Rollbar will consider call it an Error even if your default level is something other than Error.
